### PR TITLE
Specify error when entity is not entitled to wlcg.group

### DIFF
--- a/profile.md
+++ b/profile.md
@@ -570,7 +570,7 @@ with the following rules:
 *   If not explicitly included, the non-parametric `wlcg.groups` scope is implicitly added at the end of the requested scopes list whenever any group scopes are included. If no `wlcg.groups` scopes are included then it will not be added, to allow for cases where a client is only interested in capabilities.
 *   The returned `wlcg.groups` claim will not contain duplicates
 
-If an entity is not entitled to a group, the scope requested may be ignored by the server and the corresponding token may not have the corresponding claims; in this case, section 3.3 of RFC 6749 requires the token issuer to inform the client.  A server may also return an error during the authorization request.   Client software implementations should always verify the scopes present in the returned token.
+If an entity is not entitled to a group, an access_denied error as defined in section 4.1.2.1 of RFC 6749 MUST be returned.
 
 **Examples:**
 

--- a/profile.md
+++ b/profile.md
@@ -570,7 +570,7 @@ with the following rules:
 *   If not explicitly included, the non-parametric `wlcg.groups` scope is implicitly added at the end of the requested scopes list whenever any group scopes are included. If no `wlcg.groups` scopes are included then it will not be added, to allow for cases where a client is only interested in capabilities.
 *   The returned `wlcg.groups` claim will not contain duplicates
 
-If an entity is not entitled to a group, an access_denied error as defined in section 4.1.2.1 of RFC 6749 MUST be returned.
+If an entity is not entitled to a group, an access_denied error as defined in section 4.1.2.1 of RFC 6749 SHOULD be returned.  If an error is not returned, the token issuer MUST inform the client according to section 3.3 of RFC 6749.
 
 **Examples:**
 


### PR DESCRIPTION
This changes the behavior of what to do if an entity requests a group in wlcg.groups that they are not entitled to.  Instead of allowing an access token to be returned without the scope, specify an access_denied error.

This is consistent with the proposal for wlcg.capabilityset in pr #10.