### PR TITLE
Extend the token cache lifetime

### DIFF
--- a/profile.md
+++ b/profile.md
@@ -913,7 +913,7 @@ One would utilize the `iss` claim in the payload to download the set of public k
    </td>
    <td>1 hour
    </td>
-   <td>1 day
+   <td>4 days
    </td>
    <td>The public key cache lifetime defines the minimum revocation time of the public key.  The actual lifetime is the maximum allowable downtime of the public key server.
    </td>


### PR DESCRIPTION
The public key cache lifetime controls how quickly we can revoke a signer key entirely; it also controls how long of an outage we can sustain.

Based on the discussions in the WLCG authorization working group, we believe 4 days is a better tradeoff than the original 1 day.  This is still a finite time -- but allows token issuers to survive longer (e.g., weekend) outages and have the infrastructure continue to operate.