### PR TITLE
Update description of access tokens with capability and group assertions

### DIFF
--- a/profile.md
+++ b/profile.md
@@ -497,7 +497,35 @@ When groups are asserted (in an Access Token or ID Token, or both), it is a stat
 
 When a capability is asserted (only in Access Tokens), it is relative to the VO’s coarse-grained authorization; the resource only maps the token to a VO, then uses the capabilities in the token for fine-grained authorization within the VO’s authorized area.  In this way, the VO, not the resource, manages the authorizations within its area.
 
-Access tokens may convey authorization information as both groups and capabilities. If both group membership and capabilities are asserted, then the resource server should grant the union of all authorizations for the groups and capabilities that it understands.  The resource server may choose to not provide authorizations based on capabilities or may choose to not map the asserted groups to any authorization. Both assertions of group membership and capabilities are currently interpreted as positive authorizations.
+Access tokens may convey authorization information as both group and
+capability assertions.  Such duplication allows a token to function
+with services that support capability-based authorization and services
+that support only group-membership-based authorization.
+
+In general, services may be grouped into three classes: those that
+authorize operations based only on group-membership assertions, those
+that authorize operations based only on capability assertions, and
+services that can use some combination of capability and
+group-membership assertions to authorize operations.  While the
+desired behaviour of the first and second class of services is already
+defined, the intended behaviour of the third class is defined here.
+
+In general, capability-based authorization statements allows for finer
+grain authorization than is practical with the group-membership
+approach.  Therefore, in general terms, a service that supports both
+capability and group-based authorization should prefer the
+capability-based statements over the group-membership-based
+statements.
+
+More specifically, a service that supports both capability-based and
+group-membership-based authorization MUST examine each access token to
+see if it contains any of the capability statements defined above.  If
+a token has any such capability statement then the service SHOULD
+authorize a request with this token by consider that token's
+capability statements and ignore any group-membership statements.  If
+the token contains none of the capability statements defined above
+then the service SHOULD make authorization decisions based on the
+group-membership statements.
 
 
 ## Identity Assurance 

--- a/profile.md
+++ b/profile.md
@@ -519,8 +519,9 @@ statements.
 
 More specifically, a service that supports both capability-based and
 group-membership-based authorization MUST examine each access token to
-see if it contains any of the capability statements defined above.  If
-a token has any such capability statement then the service SHOULD
+see if it contains any of the capability statements defined above,
+irrespective of their relevance to the service in question.  If a
+token has any such capability statement then the service SHOULD
 authorize a request with this token by considering that token's
 capability statements and ignoring any group-membership statements.
 If the token contains none of the capability statements defined above

--- a/profile.md
+++ b/profile.md
@@ -510,7 +510,7 @@ group-membership assertions to authorize operations.  While the
 desired behaviour of the first and second class of services is already
 defined, the intended behaviour of the third class is defined here.
 
-In general, capability-based authorization statements allows for finer
+In general, capability-based authorization statements allow for finer
 grain authorization than is practical with the group-membership
 approach.  Therefore, in general terms, a service that supports both
 capability and group-based authorization should prefer the
@@ -521,9 +521,9 @@ More specifically, a service that supports both capability-based and
 group-membership-based authorization MUST examine each access token to
 see if it contains any of the capability statements defined above.  If
 a token has any such capability statement then the service SHOULD
-authorize a request with this token by consider that token's
-capability statements and ignore any group-membership statements.  If
-the token contains none of the capability statements defined above
+authorize a request with this token by considering that token's
+capability statements and ignoring any group-membership statements.
+If the token contains none of the capability statements defined above
 then the service SHOULD make authorization decisions based on the
 group-membership statements.
 


### PR DESCRIPTION
Motivation:

Currently the document defines tokens with capability and group-based authz statements.  This is undesirable as (in practical terms) the group-based statements will always allow everything that the capability approach supports, making the capabilities approach have no effect.

Moreover, switching services away from a mixed model would be a "big bang" (all or nothing) change, which carries considerable risk.

Modification:

The existing text is expanded somewhat, to describe the context better.

New semantics are introduced where services that support both capabilities and group-membership should choose capabilities when deciding whether an operation is allowed.

Result:

Group-only tokens can provide a base-line service while capabilities approach may be phased in.  It also allows for co-existence of group-membership only services with services that support capabilities.