### PR TITLE
Keep ASCII double quotes for "scope" and "wlcg.groups" attributes.

### DIFF
--- a/make-html.sh
+++ b/make-html.sh
@@ -5,14 +5,16 @@
 # Replace binary unicode sequences: some PDF converters cannot handle them.
 
 out=profile.html
+keep='(compute\.\w+ *)+|(storage\.\w+:/\S* *)+|scope|wlcg\.groups|(/\w+)+'
 
 pandoc -o $out -css profile.css profile.md &&
     perl -i -pe '
 	s/^(<h[1-6] +id="[^"]*)\./$1/;
-	s/\xE2\x80\x98/&lsquo\;/g;
-	s/\xE2\x80\x99/&rsquo\;/g;
+	s,\xE2\x80\x9C('"$keep"')\xE2\x80\x9D,"$1",g;
 	s/\xE2\x80\x9C/&ldquo\;/g;
 	s/\xE2\x80\x9D/&rdquo\;/g;
+	s/\xE2\x80\x98/&lsquo\;/g;
+	s/\xE2\x80\x99/&rsquo\;/g;
 	s/\xC2\xA0/&nbsp\;/g;
 	s/(<a [^>]+>)\xE2\x86\xA9\xEF\xB8\x8E/&nbsp;&nbsp;&nbsp;$1&#x21A9\;/g;
     ' $out


### PR DESCRIPTION
Keep ASCII double quotes for "scope" and "wlcg.groups" attributes.
